### PR TITLE
Restore HTTP404 message in case an unknown link is requested

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,4 +1,4 @@
-{% set currentPath = path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) %}
+{% set currentPath = app.request.requestUri %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
In 404 error pages there are no route. That was the reason of 500 error.