### PR TITLE
Add translation files for German and Spanish languages

### DIFF
--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
+        <body>
+        </body>
+    </file>
+</xliff>

--- a/translations/messages+intl-icu.es.xlf
+++ b/translations/messages+intl-icu.es.xlf
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
+        <body>
+        </body>
+    </file>
+</xliff>

--- a/translations/validators.de.xlf
+++ b/translations/validators.de.xlf
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
+        <body>
+        </body>
+    </file>
+</xliff>

--- a/translations/validators.es.xlf
+++ b/translations/validators.es.xlf
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
+        <body>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
Empty files are required to enable weblate translations.